### PR TITLE
Fix type on Customized Component

### DIFF
--- a/src/component/Customized.tsx
+++ b/src/component/Customized.tsx
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import { Layer } from '../container/Layer';
 import { warn } from '../util/LogUtils';
 
-type Comp<P> = FunctionComponent<P> | Component<P>;
+type Comp<P> = FunctionComponent<P> | Component<P> | ReactElement<P>;
 export type Props<P, C extends Comp<P>> = P & {
   component: C;
 };

--- a/src/component/Customized.tsx
+++ b/src/component/Customized.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Customized
  */
-import React, { isValidElement, cloneElement, createElement, Component, FunctionComponent } from 'react';
+import React, { isValidElement, cloneElement, createElement, Component, FunctionComponent, ReactElement } from 'react';
 import _ from 'lodash';
 import { Layer } from '../container/Layer';
 import { warn } from '../util/LogUtils';


### PR DESCRIPTION
In order to receive a ReactElement as the implementation expects, we need to add the type that enables that. This will fulfill the condition  `if (isValidElement(component)) {` on the component.

